### PR TITLE
Add keywords to prompt users if they would like to add the package to `require-dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
 	"license": [
 		"MIT"
 	],
+	"keywords": [
+		"static analysis"
+	],
 	"require": {
 		"php": "^7.2 || ^8.0",
 		"phpstan/phpstan": "^1.10",


### PR DESCRIPTION
If they run `composer require` without the `--dev` option, see https://getcomposer.org/doc/04-schema.md#keywords

Because I sometimes do, oops.