### PR TITLE
Test on all supported PHP versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
+          - "8.5"
 
     steps:
       - name: "Checkout"
@@ -87,6 +90,9 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
+          - "8.5"
         dependencies:
           - "lowest"
           - "highest"
@@ -124,6 +130,9 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
+          - "8.5"
         dependencies:
           - "lowest"
           - "highest"

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,6 @@
 		"phpunit/phpunit": "^9.5"
 	},
 	"config": {
-		"platform": {
-			"php": "7.4.6"
-		},
 		"sort-packages": true
 	},
 	"extra": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,12 +8,11 @@
 	<arg name="cache" value="build-cs/tmp/phpcs"/>
 	<arg value="sp"/>
 
-	<rule ref="build-cs/vendor/consistence-community/coding-standard/Consistence/ruleset.xml">
+	<rule ref="build-cs/consistence.xml">
 		<exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat"/>
 		<exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/>
-		<exclude name="Consistence.Exceptions.ExceptionDeclaration"/>
 		<exclude name="Squiz.Commenting.FunctionComment"/>
 		<exclude name="Squiz.PHP.Heredoc.NotAllowed"/>
 		<exclude name="Squiz.WhiteSpace.FunctionSpacing.Before"/>
@@ -108,7 +107,7 @@
 		</properties>
 	</rule>
 	<rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
-	<rule ref="Consistence.NamingConventions.ValidVariableName.NotCamelCaps"/>
+	<rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps"/>
 	<exclude-pattern>tests/*/data</exclude-pattern>
 	<exclude-pattern>tests/*/data-attributes</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -87,7 +87,6 @@
 	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
 		<properties>
 			<property name="searchAnnotations" value="true"/>
-			<property name="namespacesRequiredToUse" value=""/>
 			<property name="allowPartialUses" value="true"/>
 			<property name="allowFallbackGlobalFunctions" value="false"/>
 			<property name="allowFallbackGlobalConstants" value="false"/>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,3 +20,9 @@ parameters:
 			path: '*/Nette/LinkChecker.php'
 			reportUnmatched: false
 			count: 1
+		-
+			message: '#Strict comparison using === between non-empty-string and false will always evaluate to false\.#'
+			identifier: identical.alwaysFalse
+			path: '*/Nette/LinkChecker.php'
+			reportUnmatched: false
+			count: 1


### PR DESCRIPTION
Tests are green now for all PHP versions.

Had to ignore one more PHPStan error because `substr()` doesn't return `false` anymore on PHP 8.x. The ignore can be removed once PHP 7.4 support is dropped.